### PR TITLE
Add secret manager accessor role to app engine service accounts and touch up CD deploy script

### DIFF
--- a/.github/workflows/cd-cloud-dev.yml
+++ b/.github/workflows/cd-cloud-dev.yml
@@ -19,4 +19,4 @@ jobs:
           service_account_key: '${{ secrets.DEV_GCP_SA_KEY }}'
 
       - name: Deploy to dev GAE project
-        run: 'gcloud app deploy app.yaml --version ${{ env.TAG }}'
+        run: 'gcloud app deploy app.yaml --quiet --version ${{ env.TAG }}'

--- a/.github/workflows/cd-cloud-dev.yml
+++ b/.github/workflows/cd-cloud-dev.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy-dev:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.sha }}
     steps:
       - name: Checking Repository
         uses: actions/checkout@v2
@@ -17,4 +19,4 @@ jobs:
           service_account_key: '${{ secrets.DEV_GCP_SA_KEY }}'
 
       - name: Deploy to dev GAE project
-        run: 'gcloud app deploy app.yaml --quiet --no-promote --version v1'
+        run: 'gcloud app deploy app.yaml --quiet --no-promote --version ${{ env.TAG }}'

--- a/.github/workflows/cd-cloud-dev.yml
+++ b/.github/workflows/cd-cloud-dev.yml
@@ -19,4 +19,4 @@ jobs:
           service_account_key: '${{ secrets.DEV_GCP_SA_KEY }}'
 
       - name: Deploy to dev GAE project
-        run: 'gcloud app deploy app.yaml --quiet --no-promote --version ${{ env.TAG }}'
+        run: 'gcloud app deploy app.yaml --version ${{ env.TAG }}'

--- a/ops/terraform/modules/appengine/main.tf
+++ b/ops/terraform/modules/appengine/main.tf
@@ -11,4 +11,16 @@ resource "google_app_engine_application" "app" {
   location_id   = local.location_id
 }
 
+data "google_app_engine_default_service_account" "default" {
+}
 
+# Grant the app engine default account the ability to access secret manager
+
+
+resource "google_project_iam_binding" "default" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
+  ]
+}

--- a/ops/terraform/modules/service_account/main.tf
+++ b/ops/terraform/modules/service_account/main.tf
@@ -19,6 +19,14 @@ resource "google_project_iam_binding" "main" {
   ]
 }
 
+resource "google_project_iam_binding" "main_secretmanager" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  members = [
+    "serviceAccount:${google_service_account.main.email}"
+  ]
+}
+
 resource "google_secret_manager_secret" "main_publickey" {
   count     = var.use_secretsmanager ? 1 : 0
   secret_id = "${var.service_account_id}-public-key"


### PR DESCRIPTION
### Proposed Changes

- Adds the secret manager accessor role to both the app engine default service account and the service account used by content library
- Use git commit hash instead of just blanket deploying things to a `v1` tag statically

This was tested against the dev environment of library


Terraform plans for prod:

```hcl
❯ terragrunt plan --terragrunt-working-dir prod/us-east4/02_library_appengine

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/google from the dependency lock file
- Using previously-installed hashicorp/google v4.24.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.google_app_engine_default_service_account.default: Reading...
google_app_engine_application.app: Refreshing state... [id=content-library-viewer]
data.google_app_engine_default_service_account.default: Read complete after 0s [id=projects/content-library-viewer/serviceAccounts/content-library-viewer@appspot.gserviceaccount.com]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_project_iam_binding.default will be created
  + resource "google_project_iam_binding" "default" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + members = [
          + "serviceAccount:content-library-viewer@appspot.gserviceaccount.com",
        ]
      + project = "content-library-viewer"
      + role    = "roles/secretmanager.secretAccessor"
    }

Plan: 1 to add, 0 to change, 0 to destroy.


❯ terragrunt plan --terragrunt-working-dir prod/us-east4/01_service_account

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/google from the dependency lock file
- Using previously-installed hashicorp/google v4.24.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
google_service_account.main: Refreshing state... [id=projects/content-library-viewer/serviceAccounts/nytimes-library@content-library-viewer.iam.gserviceaccount.com]
google_secret_manager_secret.main_publickey[0]: Refreshing state... [id=projects/content-library-viewer/secrets/nytimes-library-public-key]
google_secret_manager_secret.main_privatekey[0]: Refreshing state... [id=projects/content-library-viewer/secrets/nytimes-library-private-key]
google_project_iam_binding.main: Refreshing state... [id=content-library-viewer/roles/datastore.user]
google_service_account_key.main[0]: Refreshing state... [id=projects/content-library-viewer/serviceAccounts/nytimes-library@content-library-viewer.iam.gserviceaccount.com/keys/81e26f31d06e3b4b52662d3ab8aa7b5114c4df46]
google_secret_manager_secret_version.main_publickey[0]: Refreshing state... [id=projects/1022301087651/secrets/nytimes-library-public-key/versions/1]
google_secret_manager_secret_version.main_privatekey[0]: Refreshing state... [id=projects/1022301087651/secrets/nytimes-library-private-key/versions/1]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # google_project_iam_binding.main_secretmanager will be created
  + resource "google_project_iam_binding" "main_secretmanager" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + members = [
          + "serviceAccount:nytimes-library@content-library-viewer.iam.gserviceaccount.com",
        ]
      + project = "content-library-viewer"
      + role    = "roles/secretmanager.secretAccessor"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```