### PR TITLE
Fix idempotency issue with google_project_iam_binding

### DIFF
--- a/ops/terraform/modules/appengine/main.tf
+++ b/ops/terraform/modules/appengine/main.tf
@@ -10,17 +10,3 @@ resource "google_app_engine_application" "app" {
   database_type = var.database_type
   location_id   = local.location_id
 }
-
-data "google_app_engine_default_service_account" "default" {
-}
-
-# Grant the app engine default account the ability to access secret manager
-
-
-resource "google_project_iam_binding" "default" {
-  project = var.project_id
-  role    = "roles/secretmanager.secretAccessor"
-  members = [
-    "serviceAccount:${data.google_app_engine_default_service_account.default.email}"
-  ]
-}

--- a/ops/terraform/modules/service_account/main.tf
+++ b/ops/terraform/modules/service_account/main.tf
@@ -19,10 +19,15 @@ resource "google_project_iam_binding" "main" {
   ]
 }
 
+data "google_app_engine_default_service_account" "default" {
+}
+
+# Grant the app engine default account the ability to access secret manager
 resource "google_project_iam_binding" "main_secretmanager" {
   project = var.project_id
   role    = "roles/secretmanager.secretAccessor"
   members = [
+    "serviceAccount:${data.google_app_engine_default_service_account.default.email}",
     "serviceAccount:${google_service_account.main.email}"
   ]
 }


### PR DESCRIPTION
### Proposed Changes

- Combines the google_project_iam_binding resource together in the service_account module instead of having one project iam binding resource in appengine module, and one in service account.

This causes an idempotency issue where each terraform run will add the secretmanager role to one of our SAs, and then remove the role from another.

This resolves the prod environment's idempotency issue:


```hcl
❯ terragrunt apply --terragrunt-working-dir prod/us-east4/01_service_account

Initializing the backend...

Initializing provider plugins...
- Reusing previous version of hashicorp/google from the dependency lock file
- Using previously-installed hashicorp/google v4.24.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
data.google_app_engine_default_service_account.default: Reading...
google_secret_manager_secret.main_publickey[0]: Refreshing state... [id=projects/content-library-viewer/secrets/nytimes-library-public-key]
google_service_account.main: Refreshing state... [id=projects/content-library-viewer/serviceAccounts/nytimes-library@content-library-viewer.iam.gserviceaccount.com]
google_secret_manager_secret.main_privatekey[0]: Refreshing state... [id=projects/content-library-viewer/secrets/nytimes-library-private-key]
data.google_app_engine_default_service_account.default: Read complete after 0s [id=projects/content-library-viewer/serviceAccounts/content-library-viewer@appspot.gserviceaccount.com]
google_project_iam_binding.main_secretmanager: Refreshing state... [id=content-library-viewer/roles/secretmanager.secretAccessor]
google_project_iam_binding.main: Refreshing state... [id=content-library-viewer/roles/datastore.user]
google_service_account_key.main[0]: Refreshing state... [id=projects/content-library-viewer/serviceAccounts/nytimes-library@content-library-viewer.iam.gserviceaccount.com/keys/81e26f31d06e3b4b52662d3ab8aa7b5114c4df46]
google_secret_manager_secret_version.main_publickey[0]: Refreshing state... [id=projects/1022301087651/secrets/nytimes-library-public-key/versions/1]
google_secret_manager_secret_version.main_privatekey[0]: Refreshing state... [id=projects/1022301087651/secrets/nytimes-library-private-key/versions/1]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

The old appengine iam binding resource was manually dropped by hand from the terraform state