### PR TITLE
Script fix to allow debugging with webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,14 +65,16 @@
   "scripts": {
     "start": "node -r dotenv/config server/bootstrap.js",
     "build": "npm run webpack",
+    "build:dev": "npm run webpack:dev",
     "debug": "node -r dotenv/config --inspect --inspect-brk server/bootstrap.js",
-    "watch": "npm run build && concurrently \"nodemon --inspect=0.0.0.0 -r dotenv/config -e js,ejs server/bootstrap.js\" \"nodemon -e scss,ts,js --watch styles --watch custom/styles --watch scripts -x npm run build\"",
+    "watch": "npm run build:dev && concurrently \"nodemon --inspect=0.0.0.0 -r dotenv/config -e js,ejs server/bootstrap.js\" \"nodemon -e scss,ts,js --watch styles --watch custom/styles --watch scripts -x npm run build:dev\"",
     "test": "NODE_ENV=test PORT=3001 jest --setupFiles dotenv/config --setupTestFrameworkScriptFile='./test/utils/bootstrap.js' --forceExit",
     "test:cover": "NODE_ENV=test PORT=3001 nyc --include=server/** --reporter=html --reporter=text jest test/**/*.test.js --setupFiles dotenv/config --setupTestFrameworkScriptFile='./test/utils/bootstrap.js' --forceExit",
     "lint": "eslint ./server",
     "lint:fix": "eslint ./server --fix",
     "gcp-build": "./bin/install_customizations && npm run build && ./bin/update_gae_pkg",
-    "webpack": "npx webpack --mode production"
+    "webpack": "npx webpack --mode=production",
+    "webpack:dev": "npx webpack --mode=development"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description of Change
Changes `npm run watch` to use the `dev` variant of the build scripts.

### Related Issue

### Motivation and Context

### Checklist
<!-- Cross out items that don't apply and leave a short description of why the item isn't relevant. Check off ([x]) items you complete. -->

- [ ] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

