### PR TITLE
Parallelize Get Secrets

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -25,7 +25,7 @@ const log = require('./logger');
       parent: parent
     })
 
-    let waiter = [];
+    const waiter = []
 
     for (const secret of secrets) {
       const path = secret.name.split('/')
@@ -35,12 +35,15 @@ const log = require('./logger');
 
       waiter.push(
         getSecret(client, secret.name, secret.labels.encoded === 'base64')
-          .then(value => process.env[envVar] = value)
-          .then(_ => log.info(`Loaded environment variable ${envVar}`)))
+          .then((value) => {
+            process.env[envVar] = value
+            log.info(`Loaded environment variable ${envVar}`)
+          })
+      )
     }
 
     await Promise.all(waiter)
-    
+
     log.info('Environment variables loaded...')
   }
 


### PR DESCRIPTION
### Description of Change
I reworked the `bootstrap.js` code to parallelize get secrets.  I didn't notice any significant impact on start up time unfortunately... Getting secrets in parallel should be something we should be doing anyways.

### Related Issue

### Motivation and Context

### Checklist
- [ ] Ran `npm run lint` and updated code style accordingly
- [ ] `npm run test` passes
- [ ] PR has a description and all contributors/stakeholder are noted/cc'ed
- [ ] tests are updated and/or added to cover new code
- [ ] relevant documentation is changed and/or added

