### PR TITLE
Deploy new image versions via kustomize manifest edits instead of image updater

### DIFF
--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -74,10 +74,11 @@ jobs:
         run: cd ops/platform-dev/overlays/${{ matrix.environment }} && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
       - name: Push kustomize edit into Github
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git config user.email "infrastructure.admin@adhocteam.us"
           git config user.name "Ad Hoc Infrastructure Bot"
+          git config --global url.https://$GITHUB_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
           git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"
           git pull --rebase
           git push

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -77,7 +77,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git config user.email "infrastructure.admin@adhocteam.us"
-          git config user.name "Github Actions"
+          git config user.name "Ad Hoc Infrastructure Bot"
           git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"
           git pull --rebase
           git push

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -1,8 +1,8 @@
 name: Build and push content library image to GCR
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 jobs:
   build-push-image:
     if: github.actor != 'jenkins-adhoc-team'
@@ -58,7 +58,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [dev]
+        environment: [dev, prod]
     needs:
       - build-push-image
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -1,10 +1,10 @@
 name: Build and push content library image to GCR
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 jobs:
-  deploy:
+  build-push-image:
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -48,3 +48,26 @@ jobs:
           cache-from: type=registry,ref=user/app:latest
           cache-to: type=inline
           tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
+
+  deploy-dev:
+    permissions:
+      contents: 'write'
+      id-token: 'write'
+      repository-projects: 'write'
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.sha }}
+    steps:
+      - name: Checking Repository
+        uses: actions/checkout@v3
+      - name: Setup Kustomize
+        uses: imranismail/setup-kustomize@6691bdeb1b0a3286fb7f70fd1423c10e81e5375f
+      - name: Set dev image version to new commit SHA
+        run: cd ops/platform-dev/overlays/dev && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
+      - name: Push kustomize edit into Github
+        run: |
+          git config user.email "infrastructure.admin@adhocteam.us"
+          git config user.name "Github Actions"
+          git commit -am "GitOps: Update Dev deployment image to ${{ env.TAG }}"
+          git pull --rebase
+          git push

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -79,10 +79,10 @@ jobs:
       - name: Push kustomize edit into Github
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
-        if: github.actor != 'github-actions'
+        if: github.actor != 'jenkins-adhoc-team'
         run: |
           git config user.email "github-actions-bot@github.com"
-          git config user.name "github-actions"
+          git config user.name "Ad Hoc Infrastructure Bot"
           git config --global url.https://$GITHUB_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
           git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"
           git pull --rebase

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -5,6 +5,7 @@ on:
     #   - main
 jobs:
   # build-push-image:
+  #   if: github.actor != 'jenkins-adhoc-team'
   #   permissions:
   #     contents: 'read'
   #     id-token: 'write'
@@ -50,6 +51,7 @@ jobs:
   #         tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
 
   deploy:
+    if: github.actor != 'jenkins-adhoc-team'
     permissions:
       contents: 'write'
       id-token: 'write'
@@ -79,7 +81,6 @@ jobs:
       - name: Push kustomize edit into Github
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
-        if: github.actor != 'Ad Hoc Infrastructure Bot'
         run: |
           git config user.email "infrastructure@adhocteam.us"
           git config user.name "Ad Hoc Infrastructure Bot"

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -54,6 +54,8 @@ jobs:
       contents: 'write'
       id-token: 'write'
       repository-projects: 'write'
+    needs:
+      - build-push-image
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.sha }}

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -72,12 +72,17 @@ jobs:
         uses: imranismail/setup-kustomize@6691bdeb1b0a3286fb7f70fd1423c10e81e5375f
       - name: Set dev image version to new commit SHA
         run: cd ops/platform-dev/overlays/${{ matrix.environment }} && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
+      
+      # The PAT method is a hacky workaround that gets around the limitation that the GHA token is not able to bypass the main branch
+      # protection rule.
+      # https://github.com/community/community/discussions/13836
       - name: Push kustomize edit into Github
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
+        if: github.actor != 'github-actions'
         run: |
-          git config user.email "infrastructure.admin@adhocteam.us"
-          git config user.name "Ad Hoc Infrastructure Bot"
+          git config user.email "github-actions-bot@github.com"
+          git config user.name "github-actions"
           git config --global url.https://$GITHUB_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
           git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"
           git pull --rebase

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        environment: [dev, prod]
+        environment: [dev]
     # needs:
     #   - build-push-image
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -49,11 +49,15 @@ jobs:
           cache-to: type=inline
           tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
 
-  deploy-dev:
+  deploy:
     permissions:
       contents: 'write'
       id-token: 'write'
       repository-projects: 'write'
+    strategy:
+      max-parallel: 1
+      matrix:
+        environment: [dev, prod]
     needs:
       - build-push-image
     runs-on: ubuntu-latest
@@ -65,11 +69,11 @@ jobs:
       - name: Setup Kustomize
         uses: imranismail/setup-kustomize@6691bdeb1b0a3286fb7f70fd1423c10e81e5375f
       - name: Set dev image version to new commit SHA
-        run: cd ops/platform-dev/overlays/dev && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
+        run: cd ops/platform-dev/overlays/${{ matrix.environment }} && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
       - name: Push kustomize edit into Github
         run: |
           git config user.email "infrastructure.admin@adhocteam.us"
           git config user.name "Github Actions"
-          git commit -am "GitOps: Update Dev deployment image to ${{ env.TAG }}"
+          git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"
           git pull --rebase
           git push

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Push kustomize edit into Github
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
-        if: github.actor != 'jenkins-adhoc-team'
+        if: github.actor != 'Ad Hoc Infrastructure Bot'
         run: |
           git config user.email "infrastructure@adhocteam.us"
           git config user.name "Ad Hoc Infrastructure Bot"

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: Checking Repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
       - name: Setup Kustomize
         uses: imranismail/setup-kustomize@6691bdeb1b0a3286fb7f70fd1423c10e81e5375f
       - name: Set dev image version to new commit SHA

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -4,54 +4,53 @@ on:
     # branches:
     #   - main
 jobs:
-  # build-push-image:
-  #   if: github.actor != 'jenkins-adhoc-team'
-  #   permissions:
-  #     contents: 'read'
-  #     id-token: 'write'
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     TAG: ${{ github.sha }}
-  #   steps:
-  #     - name: Checking Repository
-  #       uses: actions/checkout@v3
+  build-push-image:
+    if: github.actor != 'jenkins-adhoc-team'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.sha }}
+    steps:
+      - name: Checking Repository
+        uses: actions/checkout@v3
 
-  #     - name: 'Authenticate to Google Cloud'
-  #       id: auth
-  #       uses: 'google-github-actions/auth@v0.8.0'
-  #       with:
-  #         token_format: 'access_token'
-  #         workload_identity_provider: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_ID }}'
-  #         service_account: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_EMAIL }}'
+      - name: 'Authenticate to Google Cloud'
+        id: auth
+        uses: 'google-github-actions/auth@v0.8.0'
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_ID }}'
+          service_account: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_EMAIL }}'
 
-  #     - name: Setup cloud SDK with Dev project info
-  #       uses: 'google-github-actions/setup-gcloud@v0.6.0'
-  #       with:
-  #         project_id: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}'
+      - name: Setup cloud SDK with Dev project info
+        uses: 'google-github-actions/setup-gcloud@v0.6.0'
+        with:
+          project_id: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}'
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-  #     # This example uses the docker login action
-  #     - name: Log into GCR registry
-  #       uses: 'docker/login-action@v1'
-  #       with:
-  #         registry: 'gcr.io'
-  #         username: 'oauth2accesstoken'
-  #         password: '${{ steps.auth.outputs.access_token }}'
+      # This example uses the docker login action
+      - name: Log into GCR registry
+        uses: 'docker/login-action@v1'
+        with:
+          registry: 'gcr.io'
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
 
-  #     - name: Build and push image to GCR
-  #       uses: docker/build-push-action@v3
-  #       with:
-  #         context: .
-  #         pull: true
-  #         push: true
-  #         cache-from: type=registry,ref=user/app:latest
-  #         cache-to: type=inline
-  #         tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
+      - name: Build and push image to GCR
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          pull: true
+          push: true
+          cache-from: type=registry,ref=user/app:latest
+          cache-to: type=inline
+          tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
 
   deploy:
-    if: github.actor != 'jenkins-adhoc-team'
     permissions:
       contents: 'write'
       id-token: 'write'
@@ -60,8 +59,8 @@ jobs:
       max-parallel: 1
       matrix:
         environment: [dev]
-    # needs:
-    #   - build-push-image
+    needs:
+      - build-push-image
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.sha }}

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -81,7 +81,7 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
         if: github.actor != 'jenkins-adhoc-team'
         run: |
-          git config user.email "github-actions-bot@github.com"
+          git config user.email "infrastructure@adhocteam.us"
           git config user.name "Ad Hoc Infrastructure Bot"
           git config --global url.https://$GITHUB_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
           git commit -am "GitOps: Update ${{ matrix.environment }} deployment image to ${{ env.TAG }}"

--- a/.github/workflows/cd-deploy-image-to-gcr.yml
+++ b/.github/workflows/cd-deploy-image-to-gcr.yml
@@ -4,50 +4,50 @@ on:
     # branches:
     #   - main
 jobs:
-  build-push-image:
-    permissions:
-      contents: 'read'
-      id-token: 'write'
-    runs-on: ubuntu-latest
-    env:
-      TAG: ${{ github.sha }}
-    steps:
-      - name: Checking Repository
-        uses: actions/checkout@v3
+  # build-push-image:
+  #   permissions:
+  #     contents: 'read'
+  #     id-token: 'write'
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     TAG: ${{ github.sha }}
+  #   steps:
+  #     - name: Checking Repository
+  #       uses: actions/checkout@v3
 
-      - name: 'Authenticate to Google Cloud'
-        id: auth
-        uses: 'google-github-actions/auth@v0.8.0'
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_ID }}'
-          service_account: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_EMAIL }}'
+  #     - name: 'Authenticate to Google Cloud'
+  #       id: auth
+  #       uses: 'google-github-actions/auth@v0.8.0'
+  #       with:
+  #         token_format: 'access_token'
+  #         workload_identity_provider: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_ID }}'
+  #         service_account: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_WORKLOAD_IDENTITY_EMAIL }}'
 
-      - name: Setup cloud SDK with Dev project info
-        uses: 'google-github-actions/setup-gcloud@v0.6.0'
-        with:
-          project_id: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}'
+  #     - name: Setup cloud SDK with Dev project info
+  #       uses: 'google-github-actions/setup-gcloud@v0.6.0'
+  #       with:
+  #         project_id: '${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
 
-      # This example uses the docker login action
-      - name: Log into GCR registry
-        uses: 'docker/login-action@v1'
-        with:
-          registry: 'gcr.io'
-          username: 'oauth2accesstoken'
-          password: '${{ steps.auth.outputs.access_token }}'
+  #     # This example uses the docker login action
+  #     - name: Log into GCR registry
+  #       uses: 'docker/login-action@v1'
+  #       with:
+  #         registry: 'gcr.io'
+  #         username: 'oauth2accesstoken'
+  #         password: '${{ steps.auth.outputs.access_token }}'
 
-      - name: Build and push image to GCR
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          pull: true
-          push: true
-          cache-from: type=registry,ref=user/app:latest
-          cache-to: type=inline
-          tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
+  #     - name: Build and push image to GCR
+  #       uses: docker/build-push-action@v3
+  #       with:
+  #         context: .
+  #         pull: true
+  #         push: true
+  #         cache-from: type=registry,ref=user/app:latest
+  #         cache-to: type=inline
+  #         tags: gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }},gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:latest
 
   deploy:
     permissions:
@@ -58,8 +58,8 @@ jobs:
       max-parallel: 1
       matrix:
         environment: [dev, prod]
-    needs:
-      - build-push-image
+    # needs:
+    #   - build-push-image
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.sha }}
@@ -67,12 +67,14 @@ jobs:
       - name: Checking Repository
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          persist-credentials: false
       - name: Setup Kustomize
         uses: imranismail/setup-kustomize@6691bdeb1b0a3286fb7f70fd1423c10e81e5375f
       - name: Set dev image version to new commit SHA
         run: cd ops/platform-dev/overlays/${{ matrix.environment }} && kustomize edit set image gcr.io/${{ secrets.ADHOC_GCR_PLATFORM_DEV_PROJECT_ID }}/content-library:${{ env.TAG }}
       - name: Push kustomize edit into Github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           git config user.email "infrastructure.admin@adhocteam.us"
           git config user.name "Github Actions"

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: f30c5127095f3fbe2d220cd614c4043e72e6f846
+  newTag: 05fd0b4426b608c629378aec1144f3cd599b1b4b

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 68cc075b31c731aceedbce501acbbaee24d4e2db
+  newTag: d29223b5fa6ebbb75fa177f90d2d7ce4d59efcfd

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 18135849020eba23f481ec9cc0c6f342873567ad
+  newTag: 9ae5c97c0a21da5870b2aea99709fb5bc099d6ae

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: e0852fb04fe2db22fbc77928f76728acb0630dd9
+  newTag: e480f41a079255a7c3f653f76d9d99681f066ca5

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 9ae5c97c0a21da5870b2aea99709fb5bc099d6ae
+  newTag: 2a0951f98f0839849eae485f850a3af9581711d5

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 6699b2765973466966ab8c58d46a9120182f5f14
+  newTag: 49568ab34d2fcb08b4e2db8a590d06dfe189ad90

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 5198b7222fb4014e73d8b9d9e19baceeecf2229d
+  newTag: 889ca791b23bc425ad94c3ee09f482f2ee828627

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 49568ab34d2fcb08b4e2db8a590d06dfe189ad90
+  newTag: 22346a2c90091dd378137c4c92a8e95ba25a0f20

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 05fd0b4426b608c629378aec1144f3cd599b1b4b
+  newTag: 33a3759db5db65507e70d93f7d0cf4480d140cf5

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: d29223b5fa6ebbb75fa177f90d2d7ce4d59efcfd
+  newTag: f30c5127095f3fbe2d220cd614c4043e72e6f846

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 1daba6654c95d1c0994079230076397ac093d960
+  newTag: 6699b2765973466966ab8c58d46a9120182f5f14

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -10,6 +10,5 @@ patchesStrategicMerge:
 resources:
 - ../../base
 images:
-- name: gcr.io/adhoc-dev-service-platform/content-library:latest
-  newName: gcr.io/adhoc-dev-service-platform/content-library
+- name: gcr.io/adhoc-dev-service-platform/content-library
   newTag: 18135849020eba23f481ec9cc0c6f342873567ad

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 22346a2c90091dd378137c4c92a8e95ba25a0f20
+  newTag: 5198b7222fb4014e73d8b9d9e19baceeecf2229d

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 2a0951f98f0839849eae485f850a3af9581711d5
+  newTag: 68cc075b31c731aceedbce501acbbaee24d4e2db

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -2,10 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: content-library-dev
 
-bases:
-  - ../../base
 
-patches:
-  - ./serviceaccount.yaml
-  - ./ingress.yaml
-  - ./deployment.yaml
+patchesStrategicMerge:
+- ./serviceaccount.yaml
+- ./ingress.yaml
+- ./deployment.yaml
+resources:
+- ../../base
+images:
+- name: gcr.io/adhoc-dev-service-platform/content-library:latest
+  newName: gcr.io/adhoc-dev-service-platform/content-library
+  newTag: 18135849020eba23f481ec9cc0c6f342873567ad

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 889ca791b23bc425ad94c3ee09f482f2ee828627
+  newTag: e0852fb04fe2db22fbc77928f76728acb0630dd9

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: cdfaf922251a42c0be2b77441a782705ef4c10a4
+  newTag: 1daba6654c95d1c0994079230076397ac093d960

--- a/ops/platform-dev/overlays/dev/kustomization.yaml
+++ b/ops/platform-dev/overlays/dev/kustomization.yaml
@@ -11,4 +11,4 @@ resources:
 - ../../base
 images:
 - name: gcr.io/adhoc-dev-service-platform/content-library
-  newTag: 33a3759db5db65507e70d93f7d0cf4480d140cf5
+  newTag: cdfaf922251a42c0be2b77441a782705ef4c10a4


### PR DESCRIPTION
### Closes #97 

### Proposed Changes

- Updates the CD Pipeline to add a deploy job, which goes into the repository and runs `kustomize edit set image <imagename>:<git_tag_sha>`, commits and pushes the following kustomize change into Github. The change is then picked up by ArgoCD which will roll out the change asynchronously. 

### Concerns

Currently the native github actions token doesn't allow itself to push commits into protected branches. There is no "actor" that we could add to allow for a bypass of this protection rule. Solutions range from either temporarily disabling protection rules or calling API actions to create and merge PRs instantly which are all not very clean and undesired. To get around this limitation right now, we're using the Infrastructure bot user (the old Jenkins user within Ad Hoc) via a PAT with very limited access to perform this push action. This allows us to add the Jenkins user as a user that can bypass the branch restriction but with the caveat that we're using a persistent access token to perform this job.

https://github.com/community/community/discussions/13836

Let me know if this is worth the token or if we should find another way to maintain our deployments.